### PR TITLE
Change bot's automated font style to monospaced.

### DIFF
--- a/userbot/modules/pmpermit.py
+++ b/userbot/modules/pmpermit.py
@@ -17,10 +17,10 @@ from userbot import (COUNT_PM, CMD_HELP, BOTLOG, BOTLOG_CHATID,
 from userbot.events import register
 
 # ========================= CONSTANTS ============================
-UNAPPROVED_MSG = ("Bleep blop! This is a bot. Don't fret.\n\n"
-                  "My master hasn't approved you to PM."
-                  " Please wait for my master to look in, he mostly approves PMs.\n\n"
-                  "As far as I know, he doesn't usually approve retards though.")
+UNAPPROVED_MSG = ("`Bleep blop! This is a bot. Don't fret.\n\n`"
+                  "`My master hasn't approved you to PM.`"
+                  "`Please wait for my master to look in, he mostly approves PMs.\n\n`"
+                  "`As far as I know, he doesn't usually approve retards though.`")
 # =================================================================
 
 


### PR DESCRIPTION
Changing the automated bot output of pm to monospaced as, it does't even look like a bot output.Taken in consideration only the block output shows in monospaced font & thats likely to be the last two sentences before blocking.
( "`You were spamming my master's PM, which I don't like.`"
  " `I'mma Report Spam.`")