### PR TITLE
userbot: Reply to a list for easier editing, no annoying sed errors, more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ userbot/modules/sql_helper/__pycache__/*
 .vscode/*
 .idea/*
 *secret*
+error.log

--- a/userbot/modules/scrapers.py
+++ b/userbot/modules/scrapers.py
@@ -75,6 +75,7 @@ async def gsearch(q_event):
     """ For .google command, do a Google search. """
     if not q_event.text[0].isalpha() and q_event.text[0] not in (
             "/", "#", "@", "!"):
+        await q_event.edit("`Searching...`")
         match_ = q_event.pattern_match.group(1)
         match = parse.quote_plus(match_)
         result = ""

--- a/userbot/modules/sed.py
+++ b/userbot/modules/sed.py
@@ -19,10 +19,8 @@ DELIMITERS = ("/", ":", "|", "_")
 
 def separate_sed(sed_string):
     """ Separate sed arguments. """
-    if len(sed_string) < 3:
-        return
     if (
-            len(sed_string) >= 3 and
+            len(sed_string) > 3 and
             sed_string[3] in DELIMITERS and
             sed_string.count(sed_string[3]) >= 2
     ):

--- a/userbot/modules/system_stats.py
+++ b/userbot/modules/system_stats.py
@@ -76,7 +76,7 @@ async def bot_ver(event):
                 "` \n"
                 "`Revision: "
                 f"{revout}"
-                "`"
+                "` \n"
                 "`Tagged Version: r4.0`"
             )
         else:

--- a/userbot/modules/welcomes.py
+++ b/userbot/modules/welcomes.py
@@ -28,6 +28,8 @@ async def welcome_mute(welcm):
         if welcm.user_joined or welcm.user_added:
             adder = None
             ignore = None
+            spambot = False
+            users = None
 
             if welcm.user_added:
                 ignore = False
@@ -47,14 +49,12 @@ async def welcome_mute(welcm):
                 else:
                     users = [welcm.action_message.from_id]
             await sleep(5)
-            spambot = False
 
             for user_id in users:
                 async for message in bot.iter_messages(
                         welcm.chat_id,
                         from_user=user_id
                 ):
-
                     correct_type = isinstance(message, Message)
                     if not message or not correct_type:
                         break


### PR DESCRIPTION
==========**Changes in Lists:**==========
* Reply to a Paperplane list and skip <listname> in list commands
* .addlistitem(s) now requires the new items to start from a new line
* Rename .rmlist to .dellist
* Use constants for common strings
* More error checking
* Add .getlist <listname> command for a new way of getting lists

===================================

=======**Other minor changes:**========
* There is no longer an error when typing "sed" in any chat
* Show "Searching..." in .google
* Fix a minor formatting issue in .botver
* Declare variables in welcomes to avoid errors

===================================

More on the Lists module's second change:
Starting with this change, you can no longer use .addlistitem(s) like this:
.addlistitems list item 1
item 2
...

Now, it needs to be like this:
.addlistitems list
item 1
item 2
...

I have done this, because the new change allows you to omit the list name when replying, and the pattern wouldn't be able to distinguish if the given argument was the list name or an item. So, items need to be listed starting from a new line. If anyone has a better way to make this work, please suggest your changes. 