### PR TITLE
userbot: Use timezones for .date and .time, bug fixes

### DIFF
--- a/userbot/modules/lists.py
+++ b/userbot/modules/lists.py
@@ -68,7 +68,7 @@ async def removelists(event):
         elif event.pattern_match.group(1):
             listname = event.pattern_match.group(1)
         else:
-            await x.edit(f"`Pass a list to delete!` {CHK_HELP}")
+            await event.edit(f"`Pass a list to delete!` {CHK_HELP}")
             return
 
         _list = await get_list(event.chat_id, listname)
@@ -143,7 +143,7 @@ async def add_list_items(event):
 
         if not listname:
             return_msg = f"`Pass a list to add items into!` {CHK_HELP}"
-            await x.edit(return_msg)
+            await event.edit(return_msg)
             return
 
         _list = await get_list(event.chat_id, listname)
@@ -198,7 +198,7 @@ async def edit_list_item(event):
         elif event.pattern_match.group(1):
             listname = event.pattern_match.group(1)
         else:
-            await x.edit(f"`Pass a list!` {CHK_HELP}")
+            await event.edit(f"`Pass a list!` {CHK_HELP}")
             return
 
         item_number = int(event.pattern_match.group(2))
@@ -248,7 +248,7 @@ async def rmlistitems(event):
         elif event.pattern_match.group(1):
             listname = event.pattern_match.group(1)
         else:
-            await x.edit(f"`Pass a list to remove items from!` {CHK_HELP}")
+            await event.edit(f"`Pass a list to remove items from!` {CHK_HELP}")
             return
 
         item_number = int(event.pattern_match.group(2))
@@ -310,7 +310,7 @@ async def setliststate(event):
         elif event.pattern_match.group(1):
             listname = event.pattern_match.group(1)
         else:
-            await x.edit(f"`Pass a list to remove!` {CHK_HELP}")
+            await event.edit(f"`Pass a list to remove!` {CHK_HELP}")
             return
 
         _list = await get_list(event.chat_id, listname)
@@ -384,7 +384,7 @@ async def getlist_logic(event):
             elif event.pattern_match.group(1):
                 listname = event.pattern_match.group(1)
             else:
-                await x.edit(f"`Pass a list to get!` {CHK_HELP}")
+                await event.edit(f"`Pass a list to get!` {CHK_HELP}")
                 return
 
             _list = await get_list(event.chat_id, listname)

--- a/userbot/modules/time.py
+++ b/userbot/modules/time.py
@@ -18,7 +18,7 @@ from userbot.events import register, errors_handler
 
 # ===== CONSTANT =====
 COUNTRY = ''
-
+TZ_NUMBER = 1
 
 # ===== CONSTANT =====
 
@@ -40,15 +40,15 @@ async def get_tz(con):
 
     for c_code in c_n:
         if con == c_n[c_code]:
-            return tz(c_tz[c_code][0])
+            return c_tz[c_code]
     try:
         if c_n[con]:
-            return tz(c_tz[con][0])
+            return c_tz[con]
     except KeyError:
         return
 
 
-@register(outgoing=True, pattern="^.time(?: |$)(.*)")
+@register(outgoing=True, pattern="^.time(?: |$)(.*)(?<![0-9])(?: |$)([0-9]+)?")
 @errors_handler
 async def time_func(tdata):
     """ For .time command, return the time of
@@ -59,33 +59,66 @@ async def time_func(tdata):
     if not tdata.text[0].isalpha() and tdata.text[0] not in (
             "/", "#", "@", "!"):
         con = tdata.pattern_match.group(1).title()
-        t_form = "%I:%M %p"
+        tz_num = tdata.pattern_match.group(2)
 
-        if not con:
-            if not COUNTRY:
-                await tdata.edit(f"`It's`  **{dt.now().strftime(t_form)}**  `here.`")
-                return
+        t_form = "%H:%M"
+        c_name = ''
 
-            time_zone = await get_tz(COUNTRY)
+        if con:
+            try:
+                c_name = c_n[con]
+            except KeyError:
+                c_name = con
+
+            timezones = await get_tz(con)
+        elif COUNTRY:
+            c_name = COUNTRY
+            tz_num = TZ_NUMBER
+            timezones = await get_tz(COUNTRY)
+        else:
             await tdata.edit(
-                f"`It's`  **{dt.now(time_zone).strftime(t_form)}**  `here, in {COUNTRY}`"
+                f"`It's`  **{dt.now().strftime(t_form)}**  `here.`"
             )
             return
 
-        time_zone = await get_tz(con)
-        if not time_zone:
+        if not timezones:
             await tdata.edit("`Invaild country.`")
             return
 
-        try:
-            c_name = c_n[con]
-        except KeyError:
-            c_name = con
+        if len(timezones) == 1:
+            time_zone = timezones[0]
+        elif len(timezones) > 1:
+            if tz_num:
+                tz_num = int(tz_num)
+                time_zone = timezones[tz_num-1]
+            else:
+                return_str = f"{c_name} has multiple timezones:\n"
 
-        await tdata.edit(f"`It's`  **{dt.now(time_zone).strftime(t_form)}**  `in {c_name}`")
+                for i, item in enumerate(timezones):
+                    return_str += f"{i+1}. {item}\n"
+
+                return_str += "Choose one by typing the number "
+                return_str += "in the command. Example:\n"
+                return_str += f".time {c_name} 2"
+
+                await tdata.edit(return_str)
+                return
+
+        dtnow = dt.now(tz(time_zone)).strftime(t_form)
+
+        if COUNTRY:
+            await tdata.edit(
+                f"`It's`  **{dtnow}**  `here, in {COUNTRY}"
+                f"({time_zone} timezone).`"
+            )
+            return
+
+        await tdata.edit(
+            f"`It's`  **{dtnow}**  `in {c_name}({time_zone} timezone).`"
+        )
 
 
-@register(outgoing=True, pattern="^.date(?: |$)(.*)")
+@register(outgoing=True, pattern="^.date(?: |$)(.*)(?<![0-9])(?: |$)([0-9]+)?")
 @errors_handler
 async def date_func(dat):
     """ For .date command, return the date of
@@ -93,67 +126,128 @@ async def date_func(dat):
         2. The default userbot country(set it by using .settime),
         3. The server where the userbot runs.
     """
-    if not dat.text[0].isalpha() and dat.text[0] not in ("/", "#", "@", "!"):
-        d_form = "%d/%m/%y - %A"
+    if not dat.text[0].isalpha() and dat.text[0] not in (
+            "/", "#", "@", "!"):
         con = dat.pattern_match.group(1).title()
+        tz_num = dat.pattern_match.group(2)
 
-        if not con:
-            if not COUNTRY:
-                await dat.edit(f"`It's`  **{dt.now().strftime(d_form)}**  `here.`")
-                return
+        d_form = "%d/%m/%y - %A"
+        c_name = ''
 
-            time_zone = await get_tz(COUNTRY)
-            await dat.edit(
-                f"`It's`  **{dt.now(time_zone).strftime(d_form)}**  `here, in {COUNTRY}.`"
-            )
+        if con:
+            try:
+                c_name = c_n[con]
+            except KeyError:
+                c_name = con
+
+            timezones = await get_tz(con)
+        elif COUNTRY:
+            c_name = COUNTRY
+            tz_num = TZ_NUMBER
+            timezones = await get_tz(COUNTRY)
+        else:
+            await dat.edit(f"`It's`  **{dt.now().strftime(d_form)}**  `here.`")
             return
 
-        time_zone = await get_tz(con)
-        if not time_zone:
+        if not timezones:
             await dat.edit("`Invaild country.`")
             return
 
-        try:
-            c_name = c_n[con]
-        except KeyError:
-            c_name = con
+        if len(timezones) == 1:
+            time_zone = timezones[0]
+        elif len(timezones) > 1:
+            if tz_num:
+                tz_num = int(tz_num)
+                time_zone = timezones[tz_num-1]
+            else:
+                return_str = f"{c_name} has multiple timezones:\n"
 
-        await dat.edit(f"`It's`  **{dt.now().strftime(d_form)}**  `in {c_name}`")
+                for i, item in enumerate(timezones):
+                    return_str += f"{i+1}. {item}\n"
+
+                return_str += "Choose one by typing the number "
+                return_str += "in the command. Example:\n"
+                return_str += f".date {c_name} 2"
+
+                await dat.edit(return_str)
+                return
+
+        dtnow = dt.now(tz(time_zone)).strftime(d_form)
+
+        if COUNTRY:
+            await dat.edit(
+                f"`It's`  **{dtnow}**  `here, in {COUNTRY}"
+                f"({time_zone} timezone).`"
+            )
+            return
+
+        await dat.edit(
+            f"`It's`  **{dtnow}**  `in {c_name}({time_zone} timezone).`"
+        )
 
 
-@register(outgoing=True, pattern="^.settime (.*)")
+@register(outgoing=True, pattern="^.settime (.*)(?<![0-9])(?: |$)([0-9]+)?")
 @errors_handler
 async def set_time_country(loc):
     """ For .settime command, change the default userbot
         country for date and time commands. """
     if not loc.text[0].isalpha() and loc.text[0] not in ("/", "#", "@", "!"):
         global COUNTRY
+        global TZ_NUMBER
         temp_country = loc.pattern_match.group(1).title()
-
-        time_zone = await get_tz(temp_country)
-        if not time_zone:
-            await loc.edit("`Invaild country.`")
-            return
+        temp_tz_num = loc.pattern_match.group(2)
 
         try:
             c_name = c_n[temp_country]
         except KeyError:
             c_name = temp_country
 
+        timezones = await get_tz(temp_country)
+
+        if not timezones:
+            await loc.edit("`Invaild country.`")
+            return
+
+        if len(timezones) == 1:
+            TZ_NUMBER = 1
+        elif len(timezones) > 1:
+            if temp_tz_num:
+                TZ_NUMBER = int(temp_tz_num)
+            else:
+                return_str = f"{c_name} has multiple timezones:\n"
+
+                for i, item in enumerate(timezones):
+                    return_str += f"{i+1}. {item}\n"
+
+                return_str += "Choose one by typing the number "
+                return_str += "in the command. Example:\n"
+                return_str += f".settime {c_name} 2"
+
+                await loc.edit(return_str)
+                return
+
         COUNTRY = c_name
+        tz_name = timezones[TZ_NUMBER-1]
 
-        await loc.edit(f"`Set default country as {COUNTRY}. `")
+        await loc.edit("`Default country for date and time set to "
+                       f"{COUNTRY}({tz_name} timezone).`")
 
 
 CMD_HELP.update({
-    "time": ".time <country name/code>\
-    \nUsage: Get the time of a country."
+    "time": ".time <country name/code> <timezone number>"
+    "\nUsage: Get the time of a country. If a country has "
+    "multiple timezones, Paperplane will list all of them "
+    "and let you select one."
 })
 CMD_HELP.update({
-    "date": ".date <country name/code>\
-    \nUsage: Get the date of a country."
+    "date": ".date <country name/code> <timezone number>"
+    "\nUsage: Get the date of a country. If a country has "
+    "multiple timezones, Paperplane will list all of them "
+    "and let you select one."
 })
 CMD_HELP.update({
-    "settime": ".settime <country name/code>\
-    \nUsage: Set the default country for .time and .date command."
+    "settime": ".settime <country name/code> <timezone number>"
+    "\nUsage: Set the default country for .time and .date "
+    "command. If a country has multiple timezones, Paperpl"
+    "ane will list all of them and let you select one."
 })


### PR DESCRIPTION
Time module:
* .date and .time now use time zones for returning data. The user still types the country name in the command, but instead of getting the time(or date) of the first time zone, the user is asked to choose a time zone from the list of time zones available. 
* .settime command asks the user to choose a time zone and saves it as a global variable.

(Global variables(most of the necessary ones in every module) will be removed and moved to db in my next PR, they are quite not ready yet now)

Minor changes:
* Fixed a bug in Lists where a wrong Telethon event was tried to be edited, and thus threw and error when there wasn't any list item passed. 
* Also a small string change.





