### PR TITLE
DOCKERFILE - Fix minor COPY issue (?)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /root/userbot/
 #
 # Copies session and config(if it exists)
 #
-COPY ./userbot.session ./config.env* ./client_secrets.json* ./secret.json* /root/userbot/
+COPY ./sample_config.env ./userbot.session* ./config.env* ./client_secrets.json* ./secret.json* /root/userbot/
 
 #
 # Install dependencies


### PR DESCRIPTION
Since the COPY command needs at least one existing file to copy, give it the sample_config.env file (it's known to be always present - as it's cloned from the repo itself.)