### PR TITLE
docker: fix requirements errors and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,20 @@ RUN apk add --no-cache --update \
     git \
     bash \
     python3 \
-    redis \   
-    py-pillow \
-    py-requests \
+    redis \ 
+    py3-pillow \
+    py3-requests \
     libpq \
     curl \
     sudo \
     neofetch \
     musl \
-    py-tz \
+    py3-tz \
     py3-aiohttp \
-    py-six \
-    py-click
+    py3-six \
+    py3-click \
+    py3-psutil \
+    py3-lxml
 
 RUN python3 -m ensurepip \
     && pip3 install --upgrade pip setuptools \
@@ -39,7 +41,7 @@ RUN git clone -b master https://github.com/RaphielGang/Telegram-UserBot.git /roo
 # !!! NOT FOR PRODUCTION !!!
 # Copy Userbot components from Local
 #
-# COPY . /home/userbot/userbot
+# COPY . /root/userbot
 
 #
 # Make binary folder and include in PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-Pillow>=5.3.0
-aiohttp
 cowpy
 emoji
 gTTS-token>=1.1.3
@@ -16,7 +14,6 @@ pybase64>=0.4.0
 python-dotenv
 pytube>=9.5.1
 pytz
-requests>=2.18.4
 speedtest-cli>=2.0.2
 telegraph
 telethon>=1.9
@@ -26,9 +23,7 @@ spotify_token
 pymongo[srv]
 redis
 dnspython
-lxml
 humanize
 pyDownload
 PyDrive
-psutil
 pylast


### PR DESCRIPTION
Install lxml and psutil as apk packages.
Use py3 version of pillow, requests, etc
remove installed packaged via apk from requirements.txt